### PR TITLE
Fix for bug that creates one KeepAliveSocketFactory instance per request

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
@@ -322,16 +322,16 @@ public abstract class RequestOptions {
      * Sets a value to indicate whether https socket keep-alive should be disabled. Use <code>true</code> to disable
      * keep-alive; otherwise, <code>false</code>
      * <p>
-     * The default is set in the client and is by default true, indicating that https socket keep-alive will be
-     * disabled. You can change the value on this request by setting this property. You can also change the value on
+     * The default is set in the client and is by default false, indicating that https socket keep-alive will be
+     * enabled. You can change the value on this request by setting this property. You can also change the value on
      * on the {@link ServiceClient#getDefaultRequestOptions()} object so that all subsequent requests made via the
      * service client will use the appropriate value.
      * <p>
      * Setting keep-alive on https sockets is to work around a bug in the JVM where connection timeouts are not honored
-     * on retried requests. In those cases, you may choose to use socket keep-alive as a fallback. Unfortunately, the
-     * timeout value must be taken from a JVM property rather than configured locally. Therefore, in rare cases the JVM
-     * has configured aggressively short keep-alive times, it may not be beneficial to enable the use of keep-alives
-     * lest they interfere with long running data transfer operations.
+     * on retried requests. In those cases, we use socket keep-alive as a fallback. Unfortunately, the timeout value
+     * must be taken from a JVM property rather than configured locally. Therefore, in rare cases the JVM has configured
+     * aggressively short keep-alive times, it may be beneficial to disable the use of keep-alives lest they interfere
+     * with long running data transfer operations.
      *
      * @param disableHttpsSocketKeepAlive
      *           A value to indicate whether https socket keep-alive should be disabled.

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
@@ -108,7 +108,7 @@ public abstract class RequestOptions {
         }
 
         if (modifiedOptions.disableHttpsSocketKeepAlive() == null) {
-            modifiedOptions.setDisableHttpsSocketKeepAlive(true);
+            modifiedOptions.setDisableHttpsSocketKeepAlive(false);
         }
     }
 

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/BaseRequest.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/BaseRequest.java
@@ -66,11 +66,6 @@ public final class BaseRequest {
     private static String userAgent;
 
     /**
-     * Singleton instance for keepalive Socket Factory
-     */
-    private static SSLSocketFactory staticKeepAliveSocketFactory ;
-
-    /**
      * Adds the metadata.
      *
      * @param request

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/BaseRequest.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/BaseRequest.java
@@ -235,11 +235,8 @@ public final class BaseRequest {
         If we are using https, check if we should enable socket keep-alive timeouts to work around JVM bug.
          */
         if (retConnection instanceof HttpsURLConnection && !options.disableHttpsSocketKeepAlive()) {
-            if(staticKeepAliveSocketFactory == null) {
-                staticKeepAliveSocketFactory = new KeepAliveSocketFactory(HttpsURLConnection.getDefaultSSLSocketFactory());
-            }
             HttpsURLConnection httpsConnection = ((HttpsURLConnection) retConnection);
-            httpsConnection.setSSLSocketFactory(staticKeepAliveSocketFactory);
+            httpsConnection.setSSLSocketFactory(KeepAliveSocketFactory.getInstance());
         }
 
         /*

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/BaseRequest.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/BaseRequest.java
@@ -70,7 +70,6 @@ public final class BaseRequest {
      */
     private static SSLSocketFactory staticKeepAliveSocketFactory ;
 
-
     /**
      * Adds the metadata.
      *

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
@@ -61,35 +61,35 @@ public class KeepAliveSocketFactory extends SSLSocketFactory {
     }
 
     @Override
-    public synchronized Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
+    public Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
         Socket ret = delegate.createSocket(socket, s, i, b);
         ret.setKeepAlive(true);
         return ret;
     }
 
     @Override
-    public synchronized Socket createSocket(String s, int i) throws IOException, UnknownHostException {
+    public Socket createSocket(String s, int i) throws IOException, UnknownHostException {
         Socket ret = delegate.createSocket(s, i);
         ret.setKeepAlive(true);
         return ret;
     }
 
     @Override
-    public synchronized Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException, UnknownHostException {
+    public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException, UnknownHostException {
         Socket ret = delegate.createSocket(s, i, inetAddress, i1);
         ret.setKeepAlive(true);
         return ret;
     }
 
     @Override
-    public synchronized Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+    public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
         Socket ret = delegate.createSocket(inetAddress, i);
         ret.setKeepAlive(true);
         return ret;
     }
 
     @Override
-    public synchronized Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
+    public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
         Socket ret = delegate.createSocket(inetAddress, i, inetAddress1, i1);
         ret.setKeepAlive(true);
         return ret;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
@@ -61,35 +61,35 @@ public class KeepAliveSocketFactory extends SSLSocketFactory {
     }
 
     @Override
-    public Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
+    public synchronized Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
         Socket ret = delegate.createSocket(socket, s, i, b);
         ret.setKeepAlive(true);
         return ret;
     }
 
     @Override
-    public Socket createSocket(String s, int i) throws IOException, UnknownHostException {
+    public synchronized Socket createSocket(String s, int i) throws IOException, UnknownHostException {
         Socket ret = delegate.createSocket(s, i);
         ret.setKeepAlive(true);
         return ret;
     }
 
     @Override
-    public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException, UnknownHostException {
+    public synchronized Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException, UnknownHostException {
         Socket ret = delegate.createSocket(s, i, inetAddress, i1);
         ret.setKeepAlive(true);
         return ret;
     }
 
     @Override
-    public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+    public synchronized Socket createSocket(InetAddress inetAddress, int i) throws IOException {
         Socket ret = delegate.createSocket(inetAddress, i);
         ret.setKeepAlive(true);
         return ret;
     }
 
     @Override
-    public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
+    public synchronized Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
         Socket ret = delegate.createSocket(inetAddress, i, inetAddress1, i1);
         ret.setKeepAlive(true);
         return ret;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
@@ -40,17 +40,14 @@ import java.net.UnknownHostException;
 public class KeepAliveSocketFactory extends SSLSocketFactory {
     private SSLSocketFactory delegate;
 
-    private static KeepAliveSocketFactory singletonKeepAliceSocketFactory;
+    private static final KeepAliveSocketFactory singletonKeepAliveSocketFactory = new KeepAliveSocketFactory(HttpsURLConnection.getDefaultSSLSocketFactory());
 
     KeepAliveSocketFactory(SSLSocketFactory delegate) {
         this.delegate = delegate;
     }
 
     public static KeepAliveSocketFactory getInstance() {
-        if(singletonKeepAliceSocketFactory == null) {
-            singletonKeepAliceSocketFactory = new KeepAliveSocketFactory(HttpsURLConnection.getDefaultSSLSocketFactory());
-        }
-        return singletonKeepAliceSocketFactory;
+        return singletonKeepAliveSocketFactory;
     }
 
     @Override

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
@@ -15,6 +15,7 @@
 
 package com.microsoft.azure.storage.core;
 
+import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -39,8 +40,17 @@ import java.net.UnknownHostException;
 public class KeepAliveSocketFactory extends SSLSocketFactory {
     private SSLSocketFactory delegate;
 
+    private static KeepAliveSocketFactory singletonKeepAliceSocketFactory;
+
     KeepAliveSocketFactory(SSLSocketFactory delegate) {
         this.delegate = delegate;
+    }
+
+    public static KeepAliveSocketFactory getInstance() {
+        if(singletonKeepAliceSocketFactory == null) {
+            singletonKeepAliceSocketFactory = new KeepAliveSocketFactory(HttpsURLConnection.getDefaultSSLSocketFactory());
+        }
+        return singletonKeepAliceSocketFactory;
     }
 
     @Override


### PR DESCRIPTION
Changes in this PR:

- Added a static `SSLSocketFactory` object to hold a singleton instance of `KeepAliveSocketFactory`. This is set once in `BaseRequest` if the option to disable keep alive is not true.
- Re-enabled keep alive by default.

I do not know whether the option to disable keepalive should be removed altogether or not.